### PR TITLE
feat: Add 'About Us' page and navigation link

### DIFF
--- a/src/app/about/.keep
+++ b/src/app/about/.keep
@@ -1,0 +1,1 @@
+# This file is created to make Git track this directory.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const AboutPage: React.FC = () => {
+  return (
+    <>
+      <h1>About Us</h1>
+      <p>Welcome to our About Us page! We are excited to share more about our company and team.</p>
+    </>
+  );
+};
+
+export default AboutPage;

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -10,6 +10,11 @@ type Props = {};
 
 const menu = [
     {
+        label: "About",
+        url: "/about",
+        icon: () => null,
+    },
+    {
         label: "Experiments",
         url: "/experiments",
         icon: () => <Experiments />,


### PR DESCRIPTION
Adds a new 'About Us' page accessible at the /about route. Includes a basic page component with a heading and placeholder text.

A corresponding link has been added to the main navigation bar.

I skipped test creation for this page as no testing infrastructure is currently in place in your project.